### PR TITLE
[dart_lsc] Prepare for 1.0.0 version of sensors and package_info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.3
+
+* Prepare for 1.0.0 version of sensors and package_info. ([dart_lsc](http://github.com/amirh/dart_lsc))
+
 ## 0.1.2+3 - 2020/02/12.
  - FORMAT
 ## 0.1.2+2 - 2020/02/12.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: buck
 description: An assembled flutter application framework Buck, Old longings nomadic leap, Chafing at custom's chain.
-version: 0.1.2+3
+version: 0.1.3
 authors:
   - leyan95 <leyansorosame@gmail.com>
 homepage: https://github.com/leyan95/buck
@@ -22,7 +22,7 @@ dependencies:
   device_info: ^0.4.1+4
   fluttertoast: ^3.1.3
   open_file: ^3.0.0
-  package_info: ^0.4.0+13
+  package_info: '>=0.4.0+13 <2.0.0'
   permission_handler: ^4.4.0
   path_provider: ^1.6.5
   http_parser: ^3.1.3


### PR DESCRIPTION
This should be a safe change, for more details see: https://github.com/flutter/flutter/wiki/Package-migration-to-1.0.0

This change was auto generated by [dart_lsc](https://github.com/amirh/dart_lsc).